### PR TITLE
Cleanflight support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,10 @@ target_link_libraries(fcu_arm msp_fcu)
 add_executable(fcu_motors examples/fcu_motor_test.cpp)
 target_link_libraries(fcu_motors msp_fcu)
 
+# cleanflight requests
+add_executable(cleanflight_read_test examples/cleanflight_read_test.cpp)
+target_link_libraries(cleanflight_read_test msp msp_msg_print)
+
 # installation
 install(TARGETS msp
     LIBRARY DESTINATION lib

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# MultiWii Communication Library (C++)
+# MultiWii / Cleanflight Communication Library (C++)
 
-This library implements the MultiWii Serial Protocol ([MSP](http://www.multiwii.com/wiki/index.php?title=Multiwii_Serial_Protocol)) for communicating with a MultiWii flight controller (FC) over a serial device.
-It currently implements the sending and reading from a serial device and defines some of the messages and encoding/decoding functions for raw data.
+This library implements the MultiWii Serial Protocol ([MSP](http://www.multiwii.com/wiki/index.php?title=Multiwii_Serial_Protocol)) for communicating with a MultiWii or Cleanflight flight controller (FC) over a serial device.
+It defines a **low-level API** for sending+encoding and receiving+decoding MSP messages, and a **high-level API** with a subscriber pattern to periodically request data from the FC and call callback functions as soon as a message is received.
 
-The communication has been tested with MultiWii 2.4 on an Arduino Nano 3.0 where it can achieve a update rate of approximately 300Hz (for a FC cycle time of 2.8ms / 357Hz).
+The communication has been tested with MultiWii 2.4 on an Arduino Nano 3.0 where it can achieve a update rate of approximately 340Hz (for a FC cycle time of 2.8ms / 357Hz).
 
 ## Installation and Test
 ### Linux (Ubuntu / Debian)

--- a/examples/cleanflight_read_test.cpp
+++ b/examples/cleanflight_read_test.cpp
@@ -1,0 +1,44 @@
+#include <string>
+#include <iostream>
+
+#include <MSP.hpp>
+#include <msp_msg.hpp>
+#include <msg_print.hpp>
+
+int main(int argc, char *argv[]) {
+    std::string device;
+    if(argc>1)
+        device = std::string(argv[1]);
+    else
+        device = "/dev/ttyUSB0";
+
+    msp::MSP msp(device);
+
+    // wait for established connection
+    {
+    msp::Ident ident;
+    msp.request_wait(ident, 100);
+    }
+
+    std::cout << "MSP ready..." << std::endl;
+
+    msp::ApiVersion api_version;
+    msp.request_block(api_version);
+    std::cout << api_version << std::endl;
+
+    msp::FcVariant fc_variant;
+    msp.request_block(fc_variant);
+    std::cout << fc_variant << std::endl;
+
+    msp::FcVersion fc_version;
+    msp.request_block(fc_version);
+    std::cout << fc_version << std::endl;
+
+    msp::BoardInfo board_info;
+    msp.request_block(board_info);
+    std::cout << board_info << std::endl;
+
+    msp::BuildInfo build_info;
+    msp.request_block(build_info);
+    std::cout << build_info << std::endl;
+}

--- a/examples/cleanflight_read_test.cpp
+++ b/examples/cleanflight_read_test.cpp
@@ -23,22 +23,24 @@ int main(int argc, char *argv[]) {
     std::cout << "MSP ready..." << std::endl;
 
     msp::ApiVersion api_version;
-    msp.request_block(api_version);
-    std::cout << api_version << std::endl;
+    if(msp.request_block(api_version))
+        std::cout << api_version << std::endl;
+    else
+        std::cerr << "Could not determine Cleanflight API version." << std::endl;
 
     msp::FcVariant fc_variant;
-    msp.request_block(fc_variant);
-    std::cout << fc_variant << std::endl;
+    if(msp.request_block(fc_variant))
+        std::cout << fc_variant << std::endl;
 
     msp::FcVersion fc_version;
-    msp.request_block(fc_version);
-    std::cout << fc_version << std::endl;
+    if(msp.request_block(fc_version))
+        std::cout << fc_version << std::endl;
 
     msp::BoardInfo board_info;
-    msp.request_block(board_info);
-    std::cout << board_info << std::endl;
+    if(msp.request_block(board_info))
+        std::cout << board_info << std::endl;
 
     msp::BuildInfo build_info;
-    msp.request_block(build_info);
-    std::cout << build_info << std::endl;
+    if(msp.request_block(build_info))
+        std::cout << build_info << std::endl;
 }

--- a/inc/msp/FlightController.hpp
+++ b/inc/msp/FlightController.hpp
@@ -11,6 +11,11 @@ namespace fcu {
 
 typedef unsigned int uint;
 
+enum class FirmwareType {
+    MULTIWII,
+    CLEANFLIGHT
+};
+
 class SubscriptionBase {
 public:
     SubscriptionBase(PeriodicTimer *timer=NULL) : timer(timer) { }
@@ -68,6 +73,18 @@ public:
     void waitForConnection();
 
     void initialise();
+
+    /**
+     * @brief isFirmware determine firmware type (e.g. to distiguish accepted messages)
+     * @param firmware_type type of firmware (enum FirmwareType)
+     * @return true if firmware is firmware_type
+     * @return false if firmware is not firmware_type
+     */
+    bool isFirmware(const FirmwareType firmware_type);
+
+    bool isFirmwareMultiWii() { return isFirmware(FirmwareType::MULTIWII); }
+
+    bool isFirmwareCleanflight() { return isFirmware(FirmwareType::CLEANFLIGHT); }
 
     template<typename T>
     void populate(T* req) {
@@ -237,6 +254,8 @@ private:
     msp::Ident ident;
 
     std::set<msp::Sensor> sensors;
+
+    FirmwareType firmware;
 };
 
 } // namespace msp

--- a/inc/msp/msg_print.hpp
+++ b/inc/msp/msg_print.hpp
@@ -4,6 +4,16 @@
 #include "msp_msg.hpp"
 #include <ostream>
 
+std::ostream& operator<<(std::ostream& s, const msp::ApiVersion& api_version);
+
+std::ostream& operator<<(std::ostream& s, const msp::FcVariant& fc_variant);
+
+std::ostream& operator<<(std::ostream& s, const msp::FcVersion& fc_version);
+
+std::ostream& operator<<(std::ostream& s, const msp::BoardInfo& board_info);
+
+std::ostream& operator<<(std::ostream& s, const msp::BuildInfo& build_info);
+
 void operator<<(std::ostream& s, const msp::Ident& ident);
 
 void operator<<(std::ostream& s, const msp::Status& status);

--- a/inc/msp/msp_id.hpp
+++ b/inc/msp/msp_id.hpp
@@ -4,6 +4,110 @@
 namespace msp {
 
 enum class ID : uint8_t {
+    // Cleanflight
+    MSP_API_VERSION = 1,
+    MSP_FC_VARIANT  = 2,
+    MSP_FC_VERSION  = 3,
+    MSP_BOARD_INFO  = 4,
+    MSP_BUILD_INFO  = 5,
+
+    MSP_BATTERY_CONFIG            = 32,
+    MSP_SET_BATTERY_CONFIG        = 33,
+    MSP_MODE_RANGES               = 34,
+    MSP_SET_MODE_RANGE            = 35,
+    MSP_FEATURE                   = 36,
+    MSP_SET_FEATURE               = 37,
+    MSP_BOARD_ALIGNMENT           = 38,
+    MSP_SET_BOARD_ALIGNMENT       = 39,
+    MSP_AMPERAGE_METER_CONFIG     = 40,
+    MSP_SET_AMPERAGE_METER_CONFIG = 41,
+    MSP_MIXER                     = 42,
+    MSP_SET_MIXER                 = 43,
+    MSP_RX_CONFIG                 = 44,
+    MSP_SET_RX_CONFIG             = 45,
+    MSP_LED_COLORS                = 46,
+    MSP_SET_LED_COLORS            = 47,
+    MSP_LED_STRIP_CONFIG          = 48,
+    MSP_SET_LED_STRIP_CONFIG      = 49,
+    MSP_RSSI_CONFIG               = 50,
+    MSP_SET_RSSI_CONFIG           = 51,
+    MSP_ADJUSTMENT_RANGES         = 52,
+    MSP_SET_ADJUSTMENT_RANGE      = 53,
+
+    MSP_CF_SERIAL_CONFIG          = 54,
+    MSP_SET_CF_SERIAL_CONFIG      = 55,
+
+    MSP_VOLTAGE_METER_CONFIG      = 56,
+    MSP_SET_VOLTAGE_METER_CONFIG  = 57,
+
+    MSP_SONAR_ALTITUDE            = 58,
+
+    MSP_ARMING_CONFIG             = 61,
+    MSP_SET_ARMING_CONFIG         = 62,
+
+    MSP_RX_MAP                    = 64,
+    MSP_SET_RX_MAP                = 65,
+
+    MSP_REBOOT                    = 68,
+
+    MSP_BF_BUILD_INFO             = 69,
+
+    MSP_DATAFLASH_SUMMARY         = 70,
+    MSP_DATAFLASH_READ            = 71,
+    MSP_DATAFLASH_ERASE           = 72,
+
+    MSP_LOOP_TIME                 = 73,
+    MSP_SET_LOOP_TIME             = 74,
+
+    MSP_FAILSAFE_CONFIG           = 75,
+    MSP_SET_FAILSAFE_CONFIG       = 76,
+
+    MSP_RXFAIL_CONFIG             = 77,
+    MSP_SET_RXFAIL_CONFIG         = 78,
+
+    MSP_SDCARD_SUMMARY            = 79,
+
+    MSP_BLACKBOX_CONFIG           = 80,
+    MSP_SET_BLACKBOX_CONFIG       = 81,
+
+    MSP_TRANSPONDER_CONFIG        = 82,
+    MSP_SET_TRANSPONDER_CONFIG    = 83,
+
+    MSP_OSD_CHAR_WRITE            = 87,
+
+    MSP_VTX                       = 88,
+
+    MSP_OSD_VIDEO_CONFIG          = 180,
+    MSP_SET_OSD_VIDEO_CONFIG      = 181,
+    MSP_OSD_VIDEO_STATUS          = 182,
+    MSP_OSD_ELEMENT_SUMMARY       = 183,
+    MSP_OSD_LAYOUT_CONFIG         = 184,
+    MSP_SET_OSD_LAYOUT_CONFIG     = 185,
+
+    MSP_3D                  = 124,
+    MSP_RC_DEADBAND         = 125,
+    MSP_SENSOR_ALIGNMENT    = 126,
+    MSP_LED_STRIP_MODECOLOR = 127,
+    MSP_VOLTAGE_METERS      = 128,
+    MSP_AMPERAGE_METERS     = 129,
+    MSP_BATTERY_STATE       = 130,
+    MSP_PILOT               = 131,
+
+    MSP_SET_3D               	= 217,
+    MSP_SET_RC_DEADBAND      	= 218,
+    MSP_SET_RESET_CURR_PID   	= 219,
+    MSP_SET_SENSOR_ALIGNMENT 	= 220,
+    MSP_SET_LED_STRIP_MODECOLOR = 221,
+    MSP_SET_PILOT            	= 222,
+    MSP_PASSTHROUGH_SERIAL      = 244,
+
+    MSP_UID                 = 160,
+    MSP_GPSSVINFO           = 164,
+    MSP_SERVO_MIX_RULES     = 241,
+    MSP_SET_SERVO_MIX_RULE  = 242,
+    MSP_SET_4WAY_IF         = 245,
+
+    // MultiWii
     MSP_IDENT       = 100,
     MSP_STATUS      = 101,
     MSP_RAW_IMU     = 102,

--- a/inc/msp/msp_msg.hpp
+++ b/inc/msp/msp_msg.hpp
@@ -21,6 +21,12 @@ const static uint N_SERVO = 8;
 const static uint N_MOTOR = 8;
 const static uint RC_CHANS = 8;
 
+const static uint BOARD_IDENTIFIER_LENGTH = 4;
+
+const static uint BUILD_DATE_LENGTH = 11;
+const static uint BUILD_TIME_LENGTH = 8;
+const static uint GIT_SHORT_REVISION_LENGTH = 7;
+
 enum class MultiType : uint8_t {
     TRI,    // 1
     QUADP,  // 2
@@ -67,6 +73,81 @@ enum class SwitchPosition : uint {
     MID  = 1,
     HIGH = 2,
 };
+
+/////////////////////////////////////////////////////////////////////
+/// Cleanflight
+
+// MSP_API_VERSION: 1
+struct ApiVersion : public Request {
+    ID id() const { return ID::MSP_API_VERSION; }
+
+    uint protocol;
+    uint major;
+    uint minor;
+
+    void decode(const std::vector<uint8_t> &data) {
+        protocol = data[0];
+        major = data[1];
+        minor = data[2];
+    }
+};
+
+// MSP_FC_VARIANT: 2
+struct FcVariant : public Request {
+    ID id() const { return ID::MSP_FC_VARIANT; }
+
+    std::string identifier;
+
+    void decode(const std::vector<uint8_t> &data) {
+        identifier = std::string(data.begin(), data.end());
+    }
+};
+
+// MSP_FC_VERSION: 3
+struct FcVersion : public Request {
+    ID id() const { return ID::MSP_FC_VERSION; }
+
+    uint major;
+    uint minor;
+    uint patch_level;
+
+    void decode(const std::vector<uint8_t> &data) {
+        major = data[0];
+        minor = data[1];
+        patch_level = data[2];
+    }
+};
+
+// MSP_BOARD_INFO: 4
+struct BoardInfo : public Request {
+    ID id() const { return ID::MSP_BOARD_INFO; }
+
+    std::string identifier;
+    uint16_t version;
+    uint8_t type;
+
+    void decode(const std::vector<uint8_t> &data) {
+        identifier = std::string(data.begin(), data.begin()+BOARD_IDENTIFIER_LENGTH);
+        version = deserialise_uint16(data,BOARD_IDENTIFIER_LENGTH);
+        type = data[BOARD_IDENTIFIER_LENGTH+2];
+    }
+};
+
+// MSP_BUILD_INFO: 5
+struct BuildInfo : public Request {
+    ID id() const { return ID::MSP_BUILD_INFO; }
+
+    std::string buildDate;
+    std::string buildTime;
+    std::string shortGitRevision;
+
+    void decode(const std::vector<uint8_t> &data) {
+        buildDate = std::string(data[0], data[BUILD_DATE_LENGTH-1]);
+        buildTime = std::string(data[BUILD_DATE_LENGTH], data[BUILD_DATE_LENGTH+BUILD_TIME_LENGTH-1]);
+        shortGitRevision = std::string(data[BUILD_DATE_LENGTH+BUILD_TIME_LENGTH], data[BUILD_DATE_LENGTH+BUILD_TIME_LENGTH+GIT_SHORT_REVISION_LENGTH-1]);
+    }
+};
+
 
 /////////////////////////////////////////////////////////////////////
 /// Requests (1xx)

--- a/src/FlightController.cpp
+++ b/src/FlightController.cpp
@@ -18,7 +18,7 @@ void FlightController::waitForConnection() {
     std::cout<<"Wait for FC..."<<std::endl;
     msp::Ident ident;
     msp.request_wait(ident, 100);
-    std::cout<<"MSP version "<<uint(ident.version)<<" ready"<<std::endl;
+    std::cout<<"MultiWii version "<<uint(ident.version)<<" ready"<<std::endl;
 }
 
 void FlightController::initialise() {
@@ -27,7 +27,18 @@ void FlightController::initialise() {
     // wait for connection to be established
     //msp.request_timeout(ident, 1000);
     msp.request_wait(ident, 100);
-    std::cout<<"MSP version "<<uint(ident.version)<<" ready"<<std::endl;
+
+    msp::ApiVersion api;
+    if(msp.request_block(api)) {
+        // this is Cleanflight
+        firmware = FirmwareType::CLEANFLIGHT;
+        std::cout<<"Cleanflight API "<<api.major<<"."<<api.minor<<"."<<api.protocol<<" ready"<<std::endl;
+    }
+    else {
+        // this is MultiWii
+        firmware = FirmwareType::MULTIWII;
+        std::cout<<"MultiWii version "<<uint(ident.version)<<" ready"<<std::endl;
+    }
 
     // get sensors
     msp::Status status;
@@ -36,6 +47,10 @@ void FlightController::initialise() {
 
     // get boxes
     initBoxes();
+}
+
+bool FlightController::isFirmware(const FirmwareType firmware_type) {
+    return firmware == firmware_type;
 }
 
 void FlightController::populate_database() {

--- a/src/msg_print.cpp
+++ b/src/msg_print.cpp
@@ -60,7 +60,7 @@ void operator<<(std::ostream& s, const msp::Ident& ident) {
 
     s << "#Ident:" << std::endl;
 
-    s << "Version: "<<ident.version << std::endl
+    s << "MultiWii Version: "<<ident.version << std::endl
       << "MSP Version: "<<ident.msp_version << std::endl
       << "Type: " << type << std::endl
       << "Capabilities:" << std::endl;

--- a/src/msg_print.cpp
+++ b/src/msg_print.cpp
@@ -3,6 +3,41 @@
 
 typedef unsigned int uint;
 
+std::ostream& operator<<(std::ostream& s, const msp::ApiVersion& api_version) {
+    s << "#Api Version:" << std::endl;
+    s << "API: " << api_version.major << "." << api_version.minor << std::endl;
+    s << "Protocol: " << api_version.protocol << std::endl;
+    return s;
+}
+
+std::ostream& operator<<(std::ostream& s, const msp::FcVariant& fc_variant) {
+    s << "#FC variant:" << std::endl;
+    s << "Identifier: " << fc_variant.identifier << std::endl;
+    return s;
+}
+
+std::ostream& operator<<(std::ostream& s, const msp::FcVersion& fc_version) {
+    s << "#FC version:" << std::endl;
+    s << "Version: " << fc_version.major << "." << fc_version.minor << "." << fc_version.patch_level << std::endl;
+    return s;
+}
+
+std::ostream& operator<<(std::ostream& s, const msp::BoardInfo& board_info) {
+    s << "#Board Info:" << std::endl;
+    s << "Identifier: " << board_info.identifier << std::endl;
+    s << "Version: " << board_info.version << std::endl;
+    s << "Type: " << board_info.type << std::endl;
+    return s;
+}
+
+std::ostream& operator<<(std::ostream& s, const msp::BuildInfo& build_info) {
+    s << "#Build Info:" << std::endl;
+    s << "Date: " << build_info.buildDate << std::endl;
+    s << "Time: " << build_info.buildTime << std::endl;
+    s << "Git revision: " << build_info.shortGitRevision << std::endl;
+    return s;
+}
+
 void operator<<(std::ostream& s, const msp::Ident& ident) {
     std::string type;
     switch(ident.type) {


### PR DESCRIPTION
Implementation of Cleanflight messages for identifying the API version, FC and board info. After initialising a `FlightController`, the firmware type can be determined by `isFirmwareMultiWii()` and `isFirmwareCleanflight()`.