### PR TITLE
Fixed crash when client is closed

### DIFF
--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -78,7 +78,8 @@ void Client::start() {
 void Client::stop() {
     running = false;
     io.stop();
-    thread.detach();
+    port.close();
+    thread.join();
 }
 
 uint8_t Client::read() {
@@ -176,9 +177,14 @@ uint8_t Client::crc(const uint8_t id, const ByteVector &data) {
 
 void Client::processOneMessage() {
     std::lock_guard<std::mutex> lck(mutex_buffer);
-
-    const std::size_t bytes_transferred = asio::read_until(port, buffer, "$M");
-
+    std::size_t bytes_transferred = 0;
+    try {
+        bytes_transferred = asio::read_until(port, buffer, "$M");
+    } catch (std::system_error e) { 
+        //asio throws system error if port is closed while reading
+        //probably means client is being closed
+        return;
+    }
     // ignore and remove header bytes
     buffer.consume(bytes_transferred);
 

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -78,7 +78,7 @@ void Client::start() {
 void Client::stop() {
     running = false;
     io.stop();
-	port.close();
+    port.close();
     thread.join();
 }
 


### PR DESCRIPTION
In `fcu_test` (and probably others) when `Client` is closed, it's thread is detached and still runs after is is destroyed, accessing deallocated objects. Fixed to interrupt blocking serial reads and then join thread.