### PR TITLE
Value assignment via cast to type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ sudo: required
 matrix:
   include:
     # clang format check
-    - os: linux
+    - name: "Clang-Format Style Check"
+      os: linux
       before_script:
         - true  # do nothing
       script:
@@ -23,17 +24,17 @@ matrix:
     # GCC with tests
     - os: linux
       compiler: gcc
-      env: TEST="-DBUILD_TESTS=ON"
+      env: TEST="ON"
     # Clang without tests
     - os: linux
       compiler: clang
-      env: TEST="-DBUILD_TESTS=OFF"
+      env: TEST="OFF"
     - os: osx
       compiler: clang
-      env: TEST="-DBUILD_TESTS=OFF"
+      env: TEST="OFF"
     - os: windows
       env:
-        - TEST="-DBUILD_TESTS=OFF"
+        - TEST="OFF"
         - ASIO="-DASIO_HEADER_PATH=C:\asio\asio-1.12.2\include"
 
 
@@ -54,5 +55,8 @@ before_script:
   - cd build
 
 script:
-  - cmake -DBUILD_EXAMPLES=ON $TEST $ASIO ..
+  - cmake -DBUILD_EXAMPLES=ON -DBUILD_TESTS=$TEST $ASIO ..
   - cmake --build .
+  - if [[ "$TEST" == "ON" ]]; then
+      ctest --output-on-failure;
+    fi

--- a/inc/msp/Value.hpp
+++ b/inc/msp/Value.hpp
@@ -12,17 +12,27 @@ public:
      * @brief Copy assignment operator
      * @returns Reference to this object
      */
-    Value<T>& operator=(Value<T>& rhs) {
+    Value<T>& operator=(const Value<T>& rhs) {
         data.first  = rhs();
         data.second = rhs.set();
         return *this;
     }
 
     /**
+     * @brief cast to the internal type
+     */
+    operator T() const { return data.first; }
+
+    /**
+     * @brief cast to the writable refernce of internal type
+     */
+    operator T&() { return data.first; }
+
+    /**
      * @brief Assignment operator for non-Value objects
      * @returns Reference to this object
      */
-    Value<T>& operator=(T rhs) {
+    Value<T>& operator=(const T rhs) {
         data.first  = rhs;
         data.second = true;
         return *this;
@@ -51,12 +61,6 @@ public:
      * @returns Reference to the data valid flag
      */
     bool& set() { return data.second; }
-
-    /**
-     * @brief Checks if the data has been set
-     * @returns True if the data has been set
-     */
-    operator bool() const { return data.second; }
 
 private:
     std::pair<T, bool> data;

--- a/inc/msp/Value.hpp
+++ b/inc/msp/Value.hpp
@@ -21,12 +21,12 @@ public:
     /**
      * @brief cast to the internal type
      */
-    operator T() const { return data.first; }
+    explicit operator T() const { return data.first; }
 
     /**
      * @brief cast to the writable refernce of internal type
      */
-    operator T&() { return data.first; }
+    explicit operator T&() { return data.first; }
 
     /**
      * @brief Assignment operator for non-Value objects

--- a/inc/msp/msp_msg.hpp
+++ b/inc/msp/msp_msg.hpp
@@ -14,8 +14,6 @@
 #include <vector>
 #include "Message.hpp"
 
-typedef unsigned int uint;
-
 /*================================================================
  * actual messages have id and the relevant encode decode methods
  * the logic for encoding and decoding must be within a message-derived class
@@ -1009,7 +1007,7 @@ struct ModeRanges : public Message {
 
     virtual bool decode(const ByteVector& data) override {
         bool rc = true;
-        for(uint i = 0; i < MAX_MODE_ACTIVATION_CONDITION_COUNT; i++) {
+        for(size_t i = 0; i < MAX_MODE_ACTIVATION_CONDITION_COUNT; i++) {
             rc &= data.unpack(boxes[i].id);
             rc &= data.unpack(boxes[i].aux_channel_index);
             rc &= data.unpack(boxes[i].startStep);

--- a/src/FlightController.cpp
+++ b/src/FlightController.cpp
@@ -122,7 +122,7 @@ ControlSource FlightController::getControlSource() {
     msp::msg::RxConfig rxConfig(fw_variant_);
     client_.sendMessage(rxConfig);
 
-    if(rxConfig.receiverType && rxConfig.receiverType() == 4)
+    if(rxConfig.receiverType.set() && rxConfig.receiverType() == 4)
         return ControlSource::MSP;
     else if(rxConfig.serialrx_provider() == 2)
         return ControlSource::SBUS;

--- a/src/FlightController.cpp
+++ b/src/FlightController.cpp
@@ -143,10 +143,10 @@ void FlightController::generateMSP() {
     // TODO: make this respect channel mapping
     {
         std::lock_guard<std::mutex> lock(msp_updates_mutex);
-        cmds[0] = (rpyt_[3] * 500) + 1500;
-        cmds[1] = (rpyt_[0] * 500) + 1500;
-        cmds[2] = (rpyt_[1] * 500) + 1500;
-        cmds[3] = (rpyt_[2] * 500) + 1500;
+        cmds[0] = uint16_t(rpyt_[3] * 500) + 1500;
+        cmds[1] = uint16_t(rpyt_[0] * 500) + 1500;
+        cmds[2] = uint16_t(rpyt_[1] * 500) + 1500;
+        cmds[3] = uint16_t(rpyt_[2] * 500) + 1500;
 
         if(!(uint32_t(flight_mode_.modifier) &
              uint32_t(FlightMode::MODIFIER::ARM)))

--- a/test/value_test.cpp
+++ b/test/value_test.cpp
@@ -85,6 +85,21 @@ TYPED_TEST(valueTest, AssignmentMin) {
     EXPECT_TRUE(v2.set());
 }
 
+TYPED_TEST(valueTest, AssignmentCast) {
+    Value<TypeParam> v;
+    EXPECT_FALSE(v.set());
+
+    const TypeParam ref1 = std::numeric_limits<TypeParam>::max();
+
+    v = ref1;
+    EXPECT_TRUE(v.set());
+
+    EXPECT_EQ(ref1, v());
+
+    const TypeParam ref2 = v;
+    EXPECT_EQ(ref1, ref2);
+}
+
 TEST(valueTest, stringInit) {
     Value<std::string> v;
     EXPECT_EQ("", v());


### PR DESCRIPTION
This PR implements a cast operator to allow the easy access of the underlying raw data in class `Value`.
E.g.
````C++
Value<float> v = 13.4;
float data = v;
````

This clashes with the `bool` cast operator, that is used to test if a value is set. To support boolen values (i.e. `Value<bool>`) this operator is removed and one needs to check if a value is set using the `set()` method.