### PR TITLE
check on errors when opening port

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ You can connect to Arduino or Naze32 boards either by (1) using a built-in USB-t
 ### MultiWii
 - the MSP update rate is determined by variable `LOOP_TIME` in `config.h`
     - e.g. `#define LOOP_TIME 2800` sets the loop time to 2800µs and the update rate to 1/0.0028 s = 357.14 Hz
+- Some Arduino boards with an integrated USB-to-serial converter auto-reset themselves when a serial connection is established. If you send messages to the FC right after opening a connection the FC will miss your request and will not send a response. You can prevent this by either a delay between opening a connection and sending messages, or by disabling the Data Terminal Ready (DTR) line, e.g. via `stty -F /dev/ttyUSB0 -hupcl`.
 
 ### Cleanflight / Betaflight
 - change the update rate for the serial task in the range 100 ... 2000Hz

--- a/examples/client_read_test.cpp
+++ b/examples/client_read_test.cpp
@@ -10,7 +10,6 @@ int main(int argc, char *argv[]) {
     msp::client::Client client;
     client.setLoggingLevel(msp::client::LoggingLevel::WARNING);
     client.setVariant(msp::FirmwareVariant::INAV);
-    client.setVersion(2);
     client.start(device, baudrate);
 
     msp::FirmwareVariant fw_variant = msp::FirmwareVariant::INAV;

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -41,16 +41,24 @@ bool Client::stop() {
 }
 
 bool Client::connectPort(const std::string& device, const size_t baudrate) {
-    asio::error_code ec;
-    port.open(device, ec);
-    if(ec) return false;
-    port.set_option(asio::serial_port::baud_rate(uint(baudrate)));
-    port.set_option(asio::serial_port::parity(asio::serial_port::parity::none));
-    port.set_option(asio::serial_port::character_size(
-        asio::serial_port::character_size(8)));
-    port.set_option(
-        asio::serial_port::stop_bits(asio::serial_port::stop_bits::one));
-    return true;
+    try {
+        port.open(device);
+        port.set_option(asio::serial_port::baud_rate(uint(baudrate)));
+        port.set_option(
+            asio::serial_port::parity(asio::serial_port::parity::none));
+        port.set_option(asio::serial_port::character_size(
+            asio::serial_port::character_size(8)));
+        port.set_option(
+            asio::serial_port::stop_bits(asio::serial_port::stop_bits::one));
+    }
+    catch(const std::system_error& e) {
+        const int ecode = e.code().value();
+        throw std::runtime_error("Error when opening '" + device +
+                                 "': " + e.code().category().message(ecode) +
+                                 " (error code: " + std::to_string(ecode) +
+                                 ")");
+    }
+    return isConnected();
 }
 
 bool Client::disconnectPort() {


### PR DESCRIPTION
This adds exception checking when the port is opened.
Previously, a user needed to manually check the return value of the `open` method to detect issues with the configured device. By catching and reformating the exception, a user gets informed with a message if an error occurs.