### PR TITLE
const getter

### DIFF
--- a/inc/msp/Client.hpp
+++ b/inc/msp/Client.hpp
@@ -65,7 +65,7 @@ public:
      * @brief Query the cached device path
      * @return Cached path to device
      */
-    int getVersion();
+    int getVersion() const;
 
     /**
      * @brief Change the device path on the next connect
@@ -77,7 +77,7 @@ public:
      * @brief Query the cached device path
      * @return Cached path to device
      */
-    FirmwareVariant getVariant();
+    FirmwareVariant getVariant() const;
 
     /**
      * @brief Start communications with a flight controller
@@ -95,7 +95,7 @@ public:
      * @brief Query the system to see if a connection is active
      * @return true on success
      */
-    bool isConnected();
+    bool isConnected() const;
 
     /**
      * @brief Send a message to the connected flight controller. If
@@ -175,7 +175,7 @@ public:
      * @param id Message ID
      * @return True if there is already a matching subscription
      */
-    bool hasSubscription(const msp::ID& id) {
+    bool hasSubscription(const msp::ID& id) const {
         return (subscriptions.count(id) == 1);
     }
 
@@ -269,7 +269,7 @@ protected:
      * @return std::pair<iterator, bool> indicating where the start the next
      * message check operation and whether the current check was successful
      */
-    std::pair<iterator, bool> messageReady(iterator begin, iterator end);
+    std::pair<iterator, bool> messageReady(iterator begin, iterator end) const;
 
     /**
      * @brief processOneMessageV1 Iterates over characters in the ASIO buffer
@@ -295,7 +295,7 @@ protected:
      * @return ByteVector of full MSPv1 message ready for sending
      */
     ByteVector packMessageV1(const msp::ID id,
-                             const ByteVector& data = ByteVector(0));
+                             const ByteVector& data = ByteVector(0)) const;
 
     /**
      * @brief crcV1 Computes a checksum for MSPv1 messages
@@ -303,7 +303,7 @@ protected:
      * @param data Payload which is also part of the checksum
      * @return uint8_t checksum
      */
-    uint8_t crcV1(const uint8_t id, const ByteVector& data);
+    uint8_t crcV1(const uint8_t id, const ByteVector& data) const;
 
     /**
      * @brief packMessageV2 Packs data ID and data payload into a MSPv2
@@ -313,7 +313,7 @@ protected:
      * @return ByteVector of full MSPv2 message ready for sending
      */
     ByteVector packMessageV2(const msp::ID id,
-                             const ByteVector& data = ByteVector(0));
+                             const ByteVector& data = ByteVector(0)) const;
 
     /**
      * @brief crcV2 Computes a checksum for MSPv2 messages
@@ -321,7 +321,7 @@ protected:
      * @param data ByteVector of data to be wrapped into the checksum
      * @return uint8_t checksum
      */
-    uint8_t crcV2(uint8_t crc, const ByteVector& data);
+    uint8_t crcV2(uint8_t crc, const ByteVector& data) const;
 
     /**
      * @brief crcV2 Computes a checksum for MSPv2 messages
@@ -329,7 +329,7 @@ protected:
      * @param data Single byte to use in the checksum calculation
      * @return uint8_t checksum
      */
-    uint8_t crcV2(uint8_t crc, const uint8_t& b);
+    uint8_t crcV2(uint8_t crc, const uint8_t& b) const;
 
 protected:
     asio::io_service io;     ///<! io service

--- a/inc/msp/FlightController.hpp
+++ b/inc/msp/FlightController.hpp
@@ -44,7 +44,7 @@ public:
      * @brief Tests connection to a flight controller
      * @return True if connected
      */
-    bool isConnected();
+    bool isConnected() const;
 
     /**
      * @brief Sets data structure with all flags governing flight mode
@@ -56,7 +56,7 @@ public:
      * @brief Queries data structure with all flags governing flight mode
      * @return FlightMode object matchhing current flight mode flags
      */
-    FlightMode getFlightMode();
+    FlightMode getFlightMode() const;
 
     /**
      * @brief Sets which instruction source the flight controller should
@@ -103,19 +103,19 @@ public:
      * Betaflight, etc.)
      * @return msp::FirmwareVariant enum matching the current firmware
      */
-    msp::FirmwareVariant getFwVariant();
+    msp::FirmwareVariant getFwVariant() const;
 
     /**
      * @brief Queries the currently set protocol (MSPv1 or MSPv2)
      * @return integer matching the protocol version
      */
-    int getProtocolVersion();
+    int getProtocolVersion() const;
 
     /**
      * @brief Queries the currently set board name
      * @return std::String of the board name
      */
-    std::string getBoardName();
+    std::string getBoardName() const;
 
     /**
      * @brief Set the verbosity of the output
@@ -187,7 +187,7 @@ public:
      * @param id Message ID
      * @return True if there is already a subscription
      */
-    bool hasSubscription(const msp::ID &id) {
+    bool hasSubscription(const msp::ID &id) const {
         return client_.hasSubscription(id);
     }
 
@@ -221,7 +221,9 @@ public:
      * @brief Gets the information collected by the initBoxes() method
      * @return Reference to the internal mapping of strings to box IDs
      */
-    std::map<std::string, size_t> &getBoxNames() { return box_name_ids_; }
+    const std::map<std::string, size_t> &getBoxNames() const {
+        return box_name_ids_;
+    }
 
     /**
      * @brief Queries the cached flight controller information to see

--- a/inc/msp/PeriodicTimer.hpp
+++ b/inc/msp/PeriodicTimer.hpp
@@ -39,7 +39,7 @@ public:
      * @brief getPeriod get period in seconds
      * @return period in seconds
      */
-    double getPeriod() { return period_us.count() / 1.e6; }
+    double getPeriod() const { return period_us.count() / 1.e6; }
 
     /**
      * @brief setPeriod change the update period of timer thread

--- a/inc/msp/Subscription.hpp
+++ b/inc/msp/Subscription.hpp
@@ -15,37 +15,39 @@ public:
 
     virtual ~SubscriptionBase() {}
 
-    virtual void decode(msp::ByteVector& data) = 0;
+    virtual void decode(msp::ByteVector& data) const = 0;
 
-    virtual void makeRequest() = 0;
+    virtual void makeRequest() const = 0;
 
-    virtual void handleResponse() = 0;
+    virtual void handleResponse() const = 0;
 
-    virtual msp::Message& getMsgObject() = 0;
+    virtual const msp::Message& getMsgObject() const = 0;
 
     /**
      * @brief Checks to see if the subscription fires automatically
      * @returns True if the request happens automatically
      */
-    bool isAutomatic() { return hasTimer() && (timer_->getPeriod() > 0.0); }
+    bool isAutomatic() const {
+        return hasTimer() && (timer_->getPeriod() > 0.0);
+    }
 
     /**
      * @brief Checks to see if the timer has been created
      * @returns True if there is a timer
      */
-    bool hasTimer() { return timer_ ? true : false; }
+    bool hasTimer() const { return timer_ ? true : false; }
 
     /**
      * @brief Start the timer for automatic execution
      * @returns True if the timer starts successfully
      */
-    bool start() { return this->timer_->start(); }
+    bool start() const { return this->timer_->start(); }
 
     /**
      * @brief Stop the timer's automatic execution
      * @returns True if the timer stops successfully
      */
-    bool stop() { return this->timer_->stop(); }
+    bool stop() const { return this->timer_->stop(); }
 
     /**
      * @brief setTimerPeriod change the period of the timer
@@ -116,7 +118,7 @@ public:
      * @brief Virtual method for decoding received data
      * @param data Data to be unpacked
      */
-    virtual void decode(msp::ByteVector& data) override {
+    virtual void decode(msp::ByteVector& data) const override {
         io_object_->decode(data);
         recv_callback_(*io_object_);
     }
@@ -125,32 +127,36 @@ public:
      * @brief Sets the object used for packing and unpacking data
      * @param obj unique_ptr to a Message-derived object
      */
-    void setIoObject(std::unique_ptr<T>&& obj) { io_object_ = std::move(obj); }
+    void setIoObject(std::unique_ptr<T>&& obj) const {
+        io_object_ = std::move(obj);
+    }
 
     /**
      * @brief Gets a reference to the IO object
      * @returns
      */
-    T& getIoObject() { return *io_object_; }
+    const T& getIoObject() const { return *io_object_; }
 
     /**
      * @brief Gets a reference to the internal IO object as a Message
      * @returns reference to a Message
      */
-    virtual msp::Message& getMsgObject() override { return *io_object_; }
+    virtual const msp::Message& getMsgObject() const override {
+        return *io_object_;
+    }
 
     /**
      * @brief Sets the callback to be executed on success
      * @param recv_callback the callback to be executed
      */
-    void setReceiveCallback(const CallbackT& recv_callback) {
+    void setReceiveCallback(const CallbackT& recv_callback) const {
         recv_callback_ = recv_callback;
     }
 
     /**
      * @brief Calls the receive callback if it exists
      */
-    virtual void handleResponse() override {
+    virtual void handleResponse() const override {
         if(recv_callback_) recv_callback_(*io_object_);
     }
 
@@ -158,14 +164,14 @@ public:
      * @brief Sets the callback used to send the request
      * @param send_callback the callback to be executed
      */
-    void setSendCallback(const CallbackM& send_callback) {
+    void setSendCallback(const CallbackM& send_callback) const {
         send_callback_ = send_callback;
     }
 
     /**
      * @brief Calls the send callback if it exists
      */
-    virtual void makeRequest() override {
+    virtual void makeRequest() const override {
         if(send_callback_) send_callback_(*io_object_);
     }
 

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -25,11 +25,11 @@ bool Client::setVersion(const int& ver) {
     return false;
 }
 
-int Client::getVersion() { return msp_ver_; }
+int Client::getVersion() const { return msp_ver_; }
 
 void Client::setVariant(const FirmwareVariant& v) { fw_variant = v; }
 
-FirmwareVariant Client::getVariant() { return fw_variant; }
+FirmwareVariant Client::getVariant() const { return fw_variant; }
 
 bool Client::start(const std::string& device, const size_t baudrate) {
     return connectPort(device, baudrate) && startReadThread() &&
@@ -68,7 +68,7 @@ bool Client::disconnectPort() {
     return true;
 }
 
-bool Client::isConnected() { return port.is_open(); }
+bool Client::isConnected() const { return port.is_open(); }
 
 bool Client::startReadThread() {
     // no point reading if we arent connected to anything
@@ -225,7 +225,8 @@ bool Client::sendData(const msp::ID id, const ByteVector& data) {
     return (bytes_written == msg.size());
 }
 
-ByteVector Client::packMessageV1(const msp::ID id, const ByteVector& data) {
+ByteVector Client::packMessageV1(const msp::ID id,
+                                 const ByteVector& data) const {
     ByteVector msg;
     msg.push_back('$');                               // preamble1
     msg.push_back('M');                               // preamble2
@@ -237,7 +238,7 @@ ByteVector Client::packMessageV1(const msp::ID id, const ByteVector& data) {
     return msg;
 }
 
-uint8_t Client::crcV1(const uint8_t id, const ByteVector& data) {
+uint8_t Client::crcV1(const uint8_t id, const ByteVector& data) const {
     uint8_t crc = uint8_t(data.size()) ^ id;
     for(const uint8_t d : data) {
         crc = crc ^ d;
@@ -245,7 +246,8 @@ uint8_t Client::crcV1(const uint8_t id, const ByteVector& data) {
     return crc;
 }
 
-ByteVector Client::packMessageV2(const msp::ID id, const ByteVector& data) {
+ByteVector Client::packMessageV2(const msp::ID id,
+                                 const ByteVector& data) const {
     ByteVector msg;
     msg.push_back('$');                           // preamble1
     msg.push_back('X');                           // preamble2
@@ -264,14 +266,14 @@ ByteVector Client::packMessageV2(const msp::ID id, const ByteVector& data) {
     return msg;
 }
 
-uint8_t Client::crcV2(uint8_t crc, const ByteVector& data) {
+uint8_t Client::crcV2(uint8_t crc, const ByteVector& data) const {
     for(const uint8_t& p : data) {
         crc = crcV2(crc, p);
     }
     return crc;
 }
 
-uint8_t Client::crcV2(uint8_t crc, const uint8_t& b) {
+uint8_t Client::crcV2(uint8_t crc, const uint8_t& b) const {
     crc ^= b;
     for(int ii = 0; ii < 8; ++ii) {
         if(crc & 0x80) {
@@ -353,7 +355,8 @@ void Client::processOneMessage(const asio::error_code& ec,
         std::cout << "processOneMessage finished" << std::endl;
 }
 
-std::pair<iterator, bool> Client::messageReady(iterator begin, iterator end) {
+std::pair<iterator, bool> Client::messageReady(iterator begin,
+                                               iterator end) const {
     iterator i             = begin;
     const size_t available = size_t(std::distance(begin, end));
 

--- a/src/FlightController.cpp
+++ b/src/FlightController.cpp
@@ -80,7 +80,7 @@ bool FlightController::connect(const std::string &device, const size_t baudrate,
 
 bool FlightController::disconnect() { return client_.stop(); }
 
-bool FlightController::isConnected() { return client_.isConnected(); }
+bool FlightController::isConnected() const { return client_.isConnected(); }
 
 void FlightController::setLoggingLevel(const msp::client::LoggingLevel &level) {
     client_.setLoggingLevel(level);
@@ -94,7 +94,7 @@ void FlightController::setFlightMode(FlightMode mode) {
     generateMSP();
 }
 
-FlightMode FlightController::getFlightMode() { return flight_mode_; }
+FlightMode FlightController::getFlightMode() const { return flight_mode_; }
 
 void FlightController::setControlSource(ControlSource source) {
     if(source == control_source_) return;
@@ -186,11 +186,13 @@ bool FlightController::reboot() {
     return client_.sendMessage(reboot);
 }
 
-msp::FirmwareVariant FlightController::getFwVariant() { return fw_variant_; }
+msp::FirmwareVariant FlightController::getFwVariant() const {
+    return fw_variant_;
+}
 
-int FlightController::getProtocolVersion() { return msp_version_; }
+int FlightController::getProtocolVersion() const { return msp_version_; }
 
-std::string FlightController::getBoardName() { return board_name_; }
+std::string FlightController::getBoardName() const { return board_name_; }
 
 void FlightController::initBoxes() {
     // get box names


### PR DESCRIPTION
Declares methods as `const` so that read-only instances of classes `PeriodicTimer`, `Subscription`, `Client` and `FlightController` can be used.