### PR TITLE
fix project description for CMake versions older than 3.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
-cmake_minimum_required(VERSION 3.1)
-project(msp
-        LANGUAGES CXX
-        VERSION 3.3.0
-        DESCRIPTION "Implementation of the MultiWii Serial Protocol (MSP) for MultiWii and Cleanflight flight controller")
+cmake_minimum_required(VERSION 3.5)
+project(msp VERSION 3.3.0 LANGUAGES CXX)
+
+set(PROJECT_DESCRIPTION "Implementation of the MultiWii Serial Protocol (MSP) for MultiWii and Cleanflight flight controller")
+
 
 if(POLICY CMP0074)
   cmake_policy(SET CMP0074 NEW)


### PR DESCRIPTION
The `project` parameter `DESCRIPTION` is only supported by CMake versions 3.9 onwards. This PR set the `PROJECT_DESCRIPTION` manually to support older CMake versions.